### PR TITLE
MB-44727: Test for empty install location

### DIFF
--- a/cb-non-package-installer
+++ b/cb-non-package-installer
@@ -108,8 +108,9 @@ def install(package, location, package_type):
     logging.info('Installing Couchbase Server')
     if get_package_version(package)[:2] > VERSION:
         error(f'Can only install up to version {VERSION[0]}.{VERSION[1]}.X')
-    if os.listdir(location):
-        error(f'Install location "{location}" is not empty, please provide an empty directory to install to')
+    for path, directories, files in os.walk(location):
+        if file in files:
+            error(f'Install location "{location}" is not empty, please provide an empty directory to install to')
 
     unpack(package, location, package_type)
     print('Successfully installed')


### PR DESCRIPTION
In some cases, users may have an existing directory structure in place (mount points for data, logs, ...) and the installer will quit, even if the structure is empty. 